### PR TITLE
Stores real path into the $root template variable.

### DIFF
--- a/Modules-Usage/app/presenters/BasePresenter.php
+++ b/Modules-Usage/app/presenters/BasePresenter.php
@@ -7,7 +7,7 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter
 	protected function beforeRender()
 	{
 		$this->template->viewName = $this->view;
-		$this->template->root = dirname(APP_DIR);
+		$this->template->root = dirname(realpath(APP_DIR));
 
 		$a = strrpos($this->name, ':');
 		if ($a === FALSE) {


### PR DESCRIPTION
Without this change, replacement of root part of the path in the layout template on line 20 ({$presenter->template->getFile() |replace:$root}) doesn't work.
